### PR TITLE
fix: ignore unrecognizable cli parameters

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,10 @@ import { Generator } from './generator';
   const args = argv.filter(a => !a.startsWith('--'));
   const options: { [key: string]: string[] } = {};
   for (const token of argv.filter(a => a.startsWith('--'))) {
-    const [, name, value] = token.match(/--([^=]+)(?:=(.*))?/)!;
+    const match = token.match(/--([^=]+)(?:=(.*))?/);
+    if (!match)
+      continue;
+    const [, name, value] = match;
     const oldValue = options[name];
     if (oldValue)
       oldValue.push(value);


### PR DESCRIPTION
This fixes the compatibility with NPM 6 because it passed the `--` over to our CLI.

Repro: `npm init playwright@latest -- --quiet --browser=chromium`
NPM version: 6

Relates https://github.com/microsoft/playwright-vscode/issues/120 (main issue is different, thats why not closing)