### PR TITLE
devops: fix CI by installing the latest deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm i -g npm@8
+    - name: Install latest Playwright OS dependencies
+      run: |
+        cd ..
+        mkdir tmp
+        cd tmp
+        npm init -y
+        npm install @playwright/test
+        npx playwright install-deps
     - run: npm ci
-    - run: npx playwright install-deps
     - run: npm run build
     - run: npm run test


### PR DESCRIPTION
The Playwright Test version inside the repository is pinned - this means like previously we installed the dependencies of the pinned version.

Since Playwright evolves -> more dependencies get added over time. This diverges with the actual Playwright version inside the tests -> latest.