### PR TITLE
test: fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { PlaywrightTestConfig } from '@playwright/test';
-import path from 'path';
 
 const config: PlaywrightTestConfig = {
   timeout: 120 * 1000,
   testDir: './tests',
+  reporter: 'list',
 };
 
 export default config;

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -72,25 +72,37 @@ for (const packageManager of ['npm', 'yarn'] as ('npm' | 'yarn')[]) {
     });
 
     test('should generate be able to run TS examples successfully', async ({ run }) => {
+      test.slow();
       const { exitCode, dir, exec } = await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false });
       expect(exitCode).toBe(0);
       expect(fs.existsSync(path.join(dir, 'tests/example.spec.ts'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'playwright.config.ts'))).toBeTruthy();
 
-      const result = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
-      expect(result.code).toBe(0);
+      {
+        const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'install-deps']);
+        expect(code).toBe(0);
+      }
+
+      const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
+      expect(code).toBe(0);
     });
 
     test('should generate be able to run JS examples successfully', async ({ run }) => {
+      test.slow();
       const { exitCode, dir, exec } = await run([], { installGitHubActions: false, testDir: 'tests', language: 'JavaScript', installPlaywrightDependencies: false });
       expect(exitCode).toBe(0);
       expect(fs.existsSync(path.join(dir, 'tests/example.spec.js'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'playwright.config.js'))).toBeTruthy();
 
-      const result = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
-      expect(result.code).toBe(0);
+      {
+        const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'install-deps']);
+        expect(code).toBe(0);
+      }
+
+      const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
+      expect(code).toBe(0);
     });
   });
 }


### PR DESCRIPTION
The Playwright Test version inside the repository is pinned - this means like we installed the dependencies of the pinned version (GitHub workflow yml).

Since Playwright evolves -> more dependencies get added over time. This diverges with the actual Playwright version inside the tests -> latest. This change calls install-deps inside the tests too. An alternative approach would be #12 but this seems nicer.