### PR TITLE
chore: fix compatible with default TypeScript config

### DIFF
--- a/assets/example.spec.ts
+++ b/assets/example.spec.ts
@@ -387,12 +387,12 @@ async function checkNumberOfTodosInLocalStorage(page: Page, expected: number) {
 
 async function checkNumberOfCompletedTodosInLocalStorage(page: Page, expected: number) {
   return await page.waitForFunction(e => {
-    return JSON.parse(localStorage['react-todos']).filter((i: any) => i.completed).length === e;
+    return JSON.parse(localStorage['react-todos']).filter((todo: any) => todo.completed).length === e;
   }, expected);
 }
 
 async function checkTodosInLocalStorage(page: Page, title: string) {
   return await page.waitForFunction(t => {
-    return JSON.parse(localStorage['react-todos']).map((i: any) => i.title).includes(t);
+    return JSON.parse(localStorage['react-todos']).map((todo: any) => todo.title).includes(t);
   }, title);
 }

--- a/assets/example.spec.ts
+++ b/assets/example.spec.ts
@@ -387,12 +387,12 @@ async function checkNumberOfTodosInLocalStorage(page: Page, expected: number) {
 
 async function checkNumberOfCompletedTodosInLocalStorage(page: Page, expected: number) {
   return await page.waitForFunction(e => {
-    return JSON.parse(localStorage['react-todos']).filter(i => i.completed).length === e;
+    return JSON.parse(localStorage['react-todos']).filter((i: any) => i.completed).length === e;
   }, expected);
 }
 
 async function checkTodosInLocalStorage(page: Page, title: string) {
   return await page.waitForFunction(t => {
-    return JSON.parse(localStorage['react-todos']).map(i => i.title).includes(t);
+    return JSON.parse(localStorage['react-todos']).map((i: any) => i.title).includes(t);
   }, title);
 }


### PR DESCRIPTION
```txt
➜  extensiontstest npx tsc                                                                                    
src/example.spec.ts:390:59 - error TS7006: Parameter 'i' implicitly has an 'any' type.

390     return JSON.parse(localStorage['react-todos']).filter(i => i.completed).length === e;
                                                              ~

src/example.spec.ts:396:56 - error TS7006: Parameter 'i' implicitly has an 'any' type.

396     return JSON.parse(localStorage['react-todos']).map(i => i.title).includes(t);
                                                           ~


Found 2 errors in the same file, starting at: src/example.spec.ts:390
```