### PR TITLE
Change name GitHub actions step

### DIFF
--- a/assets/github-actions.yml
+++ b/assets/github-actions.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: '14.x'
     - name: Install dependencies
       run: {{installDepsCommand}}
-    - name: Install Playwright
+    - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: {{runTestsCommand}}


### PR DESCRIPTION
Change name of `npx playwright install` GitHub actions step. I think that "Install Playwright" isn't quite accurate because playwright was already installed in the previous step. What this step is actually doing is installing the browsers.