### PR TITLE
chore: use line+html in default config

### DIFF
--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -30,7 +30,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html'], ['line']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html'], ['line']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
Turns out with only the html reporter no errors get displayed on the CI inside the logs. So we can either add line, dot or list as an additional reporter, I thought list might work the best.

Relates https://github.com/debs-obrien/debbie.codes/pull/253