### PR TITLE
chore: disable opening reporters in CI

### DIFF
--- a/assets/playwright-ct.config.js
+++ b/assets/playwright-ct.config.js
@@ -20,7 +20,8 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* In CI, don't automatically open the HTML report. */
+  reporter: [['html', { open:  process.env.CI ? 'never': 'on-failure' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/assets/playwright-ct.config.ts
+++ b/assets/playwright-ct.config.ts
@@ -19,7 +19,8 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* In CI, don't automatically open the HTML report. */
+  reporter: [['html', { open:  process.env.CI ? 'never': 'on-failure' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -32,7 +32,8 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* In CI, don't automatically open the HTML report. */
+  reporter: [['html', { open:  process.env.CI ? 'never': 'on-failure' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -30,7 +30,8 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  /* In CI, don't automatically open the HTML report. */
+  reporter: [['html', { open:  process.env.CI ? 'never': 'on-failure' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */


### PR DESCRIPTION
Hola!
With the current default settings, if the test suite fails the CI will be stuck because the HTML reporter opens automatically.  
This PR changes the default config so that in CI the reporter doesn't open automatically. 