### PR TITLE
Feature/add pnpm package manager support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         cache: 'npm'
     - run: npm i -g npm@8
     - run: npm i -g yarn@1
+    - run: npm i -g pnpm@7
     - run: npm ci
     - run: npx playwright install-deps
     - run: npm run build

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -20,6 +20,7 @@ import { prompt } from 'enquirer';
 import colors from 'ansi-colors';
 
 import { executeCommands, createFiles, determinePackageManager, executeTemplate, Command, languageToFileExtension } from './utils';
+import { PackageManager } from './types';
 
 export type PromptOptions = {
   testDir: string,
@@ -32,7 +33,7 @@ export type PromptOptions = {
 const assetsDir = path.join(__dirname, '..', 'assets');
 
 export class Generator {
-  packageManager: 'npm' | 'yarn';
+  packageManager: PackageManager;
   constructor(private readonly rootDir: string, private readonly options: { [key: string]: string[] }) {
     if (!fs.existsSync(rootDir))
       fs.mkdirSync(rootDir);
@@ -145,8 +146,13 @@ export class Generator {
     }
 
     if (answers.installGitHubActions) {
+      const pmInstallCommand: Record<PackageManager, string> = {
+        npm: 'npm ci',
+        pnpm: 'pnpm',
+        yarn: 'yarn',
+      }
       const githubActionsScript = executeTemplate(this._readAsset('github-actions.yml'), {
-        installDepsCommand: this.packageManager === 'npm' ? 'npm ci' : 'yarn',
+        installDepsCommand: pmInstallCommand[this.packageManager],
         runTestsCommand: commandToRunTests(this.packageManager),
       }, new Map());
       files.set('.github/workflows/playwright.yml', githubActionsScript);
@@ -158,9 +164,19 @@ export class Generator {
     }
 
     if (!fs.existsSync(path.join(this.rootDir, 'package.json'))) {
+      const pmInitializeCommand: Record<PackageManager, string> = {
+        npm: 'npm init -y',
+        pnpm: 'pnpm init',
+        yarn: 'yarn init -y'
+      }
+      const pmOfficialName: Record<PackageManager, string> = {
+        npm: 'NPM',
+        pnpm: 'pnpm',
+        yarn: 'Yarn',
+      }
       commands.push({
-        name: `Initializing ${this.packageManager === 'yarn' ? 'Yarn' : 'NPM'} project`,
-        command: this.packageManager === 'yarn' ? 'yarn init -y' : 'npm init -y',
+        name: `Initializing ${pmOfficialName[this.packageManager]} project`,
+        command: pmInitializeCommand[this.packageManager],
       });
     }
 
@@ -171,17 +187,22 @@ export class Generator {
     if (this.options.next)
       packageLine = '@next';
 
+    const pmInstallDevDepCommand: Record<PackageManager, string> = {
+      npm: 'npm install --save-dev',
+      pnpm: 'pnpm add --save-dev',
+      yarn: 'yarn add --dev'
+    }
     if (!this.options.ct) {
       commands.push({
         name: 'Installing Playwright Test',
-        command: this.packageManager === 'yarn' ? `yarn add --dev ${packageName}${packageLine}` : `npm install --save-dev ${packageName}${packageLine}`,
+        command: `${pmInstallDevDepCommand[this.packageManager]} ${packageName}${packageLine}`,
       });
     }
 
     if (this.options.ct) {
       commands.push({
         name: 'Installing Playwright Component Testing',
-        command: this.packageManager === 'yarn' ? `yarn add --dev ${ctPackageName}${packageLine}` : `npm install --save-dev ${ctPackageName}${packageLine}`,
+        command: `${pmInstallDevDepCommand[this.packageManager]} ${ctPackageName}${packageLine}`,
       });
 
       const extension = languageToFileExtension(answers.language);
@@ -300,13 +321,17 @@ Happy hacking! 🎭`);
   }
 }
 
-export function commandToRunTests(packageManager: 'npm' | 'yarn', args?: string) {
+export function commandToRunTests(packageManager: PackageManager, args?: string) {
+  if (packageManager === 'pnpm')
+    return `pnpm playwright test${args ? (' ' + args) : ''}`;
   if (packageManager === 'yarn')
     return `yarn playwright test${args ? (' ' + args) : ''}`;
   return `npx playwright test${args ? (' ' + args) : ''}`;
 }
 
-export function commandToRunCodegen(packageManager: 'npm' | 'yarn') {
+export function commandToRunCodegen(packageManager: PackageManager) {
+  if (packageManager === 'pnpm')
+    return `pnpm playwright codegen`;
   if (packageManager === 'yarn')
     return `yarn playwright codegen`;
   return `npx playwright codegen`;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -148,7 +148,7 @@ export class Generator {
     if (answers.installGitHubActions) {
       const pmInstallCommand: Record<PackageManager, string> = {
         npm: 'npm ci',
-        pnpm: 'pnpm',
+        pnpm: 'pnpm install',
         yarn: 'yarn',
       }
       const githubActionsScript = executeTemplate(this._readAsset('github-actions.yml'), {
@@ -171,7 +171,7 @@ export class Generator {
       }
       const pmOfficialName: Record<PackageManager, string> = {
         npm: 'NPM',
-        pnpm: 'pnpm',
+        pnpm: 'Pnpm',
         yarn: 'Yarn',
       }
       commands.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type PackageManager = 'npm' | 'pnpm' | 'yarn'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ import path from 'path';
 
 import { prompt } from 'enquirer';
 import colors from 'ansi-colors';
+import { PackageManager } from './types';
 
 export type Command = {
   command: string;
@@ -55,11 +56,18 @@ export async function createFiles(rootDir: string, files: Map<string, string>, f
   }
 }
 
-export function determinePackageManager(rootDir: string): 'yarn' | 'npm' {
+export function determinePackageManager(rootDir: string): PackageManager {
   if (fs.existsSync(path.join(rootDir, 'yarn.lock')))
     return 'yarn';
-  if (process.env.npm_config_user_agent)
-    return process.env.npm_config_user_agent.includes('yarn') ? 'yarn' : 'npm';
+  if (fs.existsSync(path.join(rootDir, 'pnpm-lock.yaml')))
+    return 'pnpm';
+  if (process.env.npm_config_user_agent) {
+    if (process.env.npm_config_user_agent.includes('yarn'))
+      return 'yarn'
+    if (process.env.npm_config_user_agent.includes('pnpm'))
+      return 'pnpm'
+    return 'npm';
+  }
   return 'npm';
 }
 

--- a/tests/baseFixtures.ts
+++ b/tests/baseFixtures.ts
@@ -59,6 +59,8 @@ export const test = base.extend<TestFixtures>({
       fs.mkdirSync(testInfo.outputDir, { recursive: true });
       const env = packageManager === 'yarn' ? {
         'npm_config_user_agent': 'yarn'
+      } : packageManager === 'pnpm' ? {
+        'npm_config_user_agent': 'pnpm/0.0.0'
       } : undefined;
       const result = await spawnAsync('node', [path.join(__dirname, '..'), ...parameters], {
         shell: true,

--- a/tests/baseFixtures.ts
+++ b/tests/baseFixtures.ts
@@ -19,9 +19,10 @@ import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { PromptOptions } from '../src/generator';
+import { PackageManager } from '../src/types';
 
 type TestFixtures = {
-  packageManager: 'npm' | 'yarn';
+  packageManager: PackageManager;
   run: (parameters: string[], options: PromptOptions) => Promise<RunResult>,
 };
 

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -46,7 +46,7 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
         expect(stdout).toContain('Initializing Yarn project (yarn init -y)…');
         expect(stdout).toContain('Installing Playwright Test (yarn add --dev @playwright/test)…');
       } else if (packageManager === 'pnpm') {
-        expect(stdout).toContain('Initializing PNPM project (pnpm init)…');
+        expect(stdout).toContain('pnpm init'); // pnpm command outputs name in different case, hence we are not testing the whole string
         expect(stdout).toContain('Installing Playwright Test (pnpm add --save-dev @playwright/test)…');
       }
       expect(stdout).toContain('npx playwright install' + process.platform === 'linux' ? ' --with-deps' : '');

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -16,8 +16,9 @@
 import { test, expect } from './baseFixtures';
 import path from 'path';
 import fs from 'fs';
+import { PackageManager } from '../src/types';
 
-for (const packageManager of ['npm', 'yarn'] as ('npm' | 'yarn')[]) {
+for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
   test.describe(`Package manager: ${packageManager}`, () => {
     test.use({ packageManager });
 

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -30,8 +30,10 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
       if (packageManager === 'npm')
         expect(fs.existsSync(path.join(dir, 'package-lock.json'))).toBeTruthy();
-      else
+      else if  (packageManager === 'yarn')
         expect(fs.existsSync(path.join(dir, 'yarn.lock'))).toBeTruthy();
+      else if (packageManager === 'pnpm')
+        expect(fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'playwright.config.ts'))).toBeTruthy();
       const playwrightConfigContent = fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8');
       expect(playwrightConfigContent).toContain('tests');
@@ -40,9 +42,12 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       if (packageManager === 'npm') {
         expect(stdout).toContain('Initializing NPM project (npm init -y)…');
         expect(stdout).toContain('Installing Playwright Test (npm install --save-dev @playwright/test)…');
-      } else {
+      } else if (packageManager === 'yarn') {
         expect(stdout).toContain('Initializing Yarn project (yarn init -y)…');
         expect(stdout).toContain('Installing Playwright Test (yarn add --dev @playwright/test)…');
+      } else if (packageManager === 'pnpm') {
+        expect(stdout).toContain('Initializing PNPM project (pnpm init)…');
+        expect(stdout).toContain('Installing Playwright Test (pnpm add --save-dev @playwright/test)…');
       }
       expect(stdout).toContain('npx playwright install' + process.platform === 'linux' ? ' --with-deps' : '');
     });
@@ -54,8 +59,10 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       expect(fs.existsSync(path.join(dir, 'foobar/package.json'))).toBeTruthy();
       if (packageManager === 'npm')
         expect(fs.existsSync(path.join(dir, 'foobar/package-lock.json'))).toBeTruthy();
-      else
+      else if (packageManager === 'yarn')
         expect(fs.existsSync(path.join(dir, 'foobar/yarn.lock'))).toBeTruthy();
+      else if (packageManager === 'pnpm')
+        expect(fs.existsSync(path.join(dir, 'foobar/pnpm-lock.yaml'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'foobar/playwright.config.ts'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'foobar/.github/workflows/playwright.yml'))).toBeTruthy();
     });
@@ -67,8 +74,10 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
       if (packageManager === 'npm')
         expect(fs.existsSync(path.join(dir, 'package-lock.json'))).toBeTruthy();
-      else
+      else if (packageManager === 'yarn')
         expect(fs.existsSync(path.join(dir, 'yarn.lock'))).toBeTruthy();
+      else if (packageManager === 'pnpm')
+        expect(fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, 'playwright.config.js'))).toBeTruthy();
       expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeFalsy();
     });
@@ -82,11 +91,11 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       expect(fs.existsSync(path.join(dir, 'playwright.config.ts'))).toBeTruthy();
 
       {
-        const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'install-deps']);
+        const { code } = await exec(packageManager === 'npm' ? 'npx' : packageManager === 'pnpm' ? 'pnpm dlx' : 'yarn', ['playwright', 'install-deps']);
         expect(code).toBe(0);
       }
 
-      const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
+      const { code } = await exec(packageManager === 'npm' ? 'npx' : packageManager === 'pnpm' ? 'pnpm dlx' : 'yarn', ['playwright', 'test']);
       expect(code).toBe(0);
     });
 
@@ -99,11 +108,11 @@ for (const packageManager of ['npm', 'pnpm', 'yarn'] as PackageManager[]) {
       expect(fs.existsSync(path.join(dir, 'playwright.config.js'))).toBeTruthy();
 
       {
-        const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'install-deps']);
+        const { code } = await exec(packageManager === 'npm' ? 'npx' : packageManager === 'pnpm' ? 'pnpm dlx' : 'yarn', ['playwright', 'install-deps']);
         expect(code).toBe(0);
       }
 
-      const { code } = await exec(packageManager === 'npm' ? 'npx' : 'yarn', ['playwright', 'test']);
+      const { code } = await exec(packageManager === 'npm' ? 'npx' : packageManager === 'pnpm' ? 'pnpm dlx' : 'yarn', ['playwright', 'test']);
       expect(code).toBe(0);
     });
   });


### PR DESCRIPTION
**Context**
`pnpm` is an increasingly popular package manager with several benefits over `npm` which results in extremely quick installations of dependencies. https://pnpm.io/

**Why**
When I tried running `pnpm create playwright`, the installation failed.

<img width="1252" alt="Screenshot 2022-08-02 at 21 29 35" src="https://user-images.githubusercontent.com/988706/182457953-abfc2719-1b1b-42c3-b09f-d306efe5f65a.png">



**Implemented**
* Added `PackageManager` type
* Refactor some existing code; added support for `pnpm`
* Updated tests