### PR TITLE
feat: generate Page-Object-Model test example

### DIFF
--- a/assets/playwright-dev-page.js
+++ b/assets/playwright-dev-page.js
@@ -1,0 +1,29 @@
+const { expect } = require('@playwright/test');
+
+exports.PlaywrightDevPage = class PlaywrightDevPage {
+
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.getStartedLink = page.locator('a', { hasText: 'Get started' });
+    this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
+    this.pomLink = page.locator('li', { hasText: 'Guides' }).locator('a', { hasText: 'Page Object Model' });
+    this.tocList = page.locator('article div.markdown ul > li > a');
+  }
+
+  async goto() {
+    await this.page.goto('https://playwright.dev');
+  }
+
+  async getStarted() {
+    await this.getStartedLink.first().click();
+    await expect(this.gettingStartedHeader).toBeVisible();
+  }
+
+  async pageObjectModel() {
+    await this.getStarted();
+    await this.pomLink.click();
+  }
+}

--- a/assets/playwright-dev-page.ts
+++ b/assets/playwright-dev-page.ts
@@ -1,0 +1,31 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export class PlaywrightDevPage {
+  readonly page: Page;
+  readonly getStartedLink: Locator;
+  readonly gettingStartedHeader: Locator;
+  readonly pomLink: Locator;
+  readonly tocList: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.getStartedLink = page.locator('a', { hasText: 'Get started' });
+    this.gettingStartedHeader = page.locator('h1', { hasText: 'Installation' });
+    this.pomLink = page.locator('li', { hasText: 'Guides' }).locator('a', { hasText: 'Page Object Model' });
+    this.tocList = page.locator('article div.markdown ul > li > a');
+  }
+
+  async goto() {
+    await this.page.goto('https://playwright.dev');
+  }
+
+  async getStarted() {
+    await this.getStartedLink.first().click();
+    await expect(this.gettingStartedHeader).toBeVisible();
+  }
+
+  async pageObjectModel() {
+    await this.getStarted();
+    await this.pomLink.click();
+  }
+}

--- a/assets/pom-example.spec.js
+++ b/assets/pom-example.spec.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('@playwright/test');
+const { PlaywrightDevPage } = require('./playwright-dev-page');
+
+test('getting started should contain table of contents', async ({ page }) => {
+  const playwrightDev = new PlaywrightDevPage(page);
+  await playwrightDev.goto();
+  await playwrightDev.getStarted();
+  await expect(playwrightDev.tocList).toHaveText([
+    `How to install Playwright`,
+    `What's Installed`,
+    `How to run the example test`,
+    `How to open the HTML test report`,
+    `Write tests using web first assertions, page fixtures and locators`,
+    `Run single tests, multiple tests, headed mode`,
+    `Generate tests with Codegen`,
+    `See a trace of your tests`
+  ]);
+});
+
+test('should show Page Object Model article', async ({ page }) => {
+  const playwrightDev = new PlaywrightDevPage(page);
+  await playwrightDev.goto();
+  await playwrightDev.pageObjectModel();
+  await expect(page.locator('article')).toContainText('Page Object Model is a common pattern');
+});

--- a/assets/pom-example.spec.ts
+++ b/assets/pom-example.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { PlaywrightDevPage } from './playwright-dev-page';
+
+test('getting started should contain table of contents', async ({ page }) => {
+  const playwrightDev = new PlaywrightDevPage(page);
+  await playwrightDev.goto();
+  await playwrightDev.getStarted();
+  await expect(playwrightDev.tocList).toHaveText([
+    `How to install Playwright`,
+    `What's Installed`,
+    `How to run the example test`,
+    `How to open the HTML test report`,
+    `Write tests using web first assertions, page fixtures and locators`,
+    `Run single tests, multiple tests, headed mode`,
+    `Generate tests with Codegen`,
+    `See a trace of your tests`
+  ]);
+});
+
+test('should show Page Object Model article', async ({ page }) => {
+  const playwrightDev = new PlaywrightDevPage(page);
+  await playwrightDev.goto();
+  await playwrightDev.pageObjectModel();
+  await expect(page.locator('article')).toContainText('Page Object Model is a common pattern');
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ function _printHelp() {
       --ct: install Playwright Component testing
       --quiet: do not ask for interactive input prompts
       --gha: install GitHub Actions
+      --pom: generate Page-Object-Model test example
       --lang=<js>: language to use (default: 'TypeScript'. Potential values: 'js', 'TypeScript')
     `);
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -25,6 +25,7 @@ import { packageManager } from './packageManager';
 export type PromptOptions = {
   testDir: string,
   installGitHubActions: boolean,
+  generatePomTest: boolean,
   language: 'JavaScript' | 'TypeScript',
   framework?: 'react' | 'vue' | 'svelte' | undefined,
   installPlaywrightDependencies: boolean,
@@ -64,6 +65,7 @@ export class Generator {
     if (this.options.quiet) {
       return {
         installGitHubActions: !!this.options.gha,
+        generatePomTest: !!this.options.gha,
         language: this.options.lang?.[0] === 'js' ? 'JavaScript' : 'TypeScript',
         installPlaywrightDependencies: !!this.options['install-deps'],
         testDir: fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests',
@@ -105,6 +107,12 @@ export class Generator {
         name: 'installGitHubActions',
         message: 'Add a GitHub Actions workflow?',
         initial: false,
+      },
+      !this.options.ct && {
+        type: 'confirm',
+        name: 'generatePomTest',
+        message: 'Do you want to generate Page-Object-Model test example?',
+        initial: false
       },
       {
         type: 'confirm',
@@ -157,6 +165,11 @@ export class Generator {
         runTestsCommand: packageManager.runPlaywrightTest(),
       }, new Map());
       files.set('.github/workflows/playwright.yml', githubActionsScript);
+    }
+
+    if (answers.generatePomTest) {
+      files.set(path.join('tests-examples-pom', `pom-example.spec.${fileExtension}`), this._readAsset(`pom-example.spec.${fileExtension}`));
+      files.set(path.join('tests-examples-pom', `playwright-dev-page.${fileExtension}`), this._readAsset(`playwright-dev-page.${fileExtension}`));
     }
 
     if (installExamples) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -65,7 +65,7 @@ export class Generator {
     if (this.options.quiet) {
       return {
         installGitHubActions: !!this.options.gha,
-        generatePomTest: !!this.options.gha,
+        generatePomTest: !!this.options.pom,
         language: this.options.lang?.[0] === 'js' ? 'JavaScript' : 'TypeScript',
         installPlaywrightDependencies: !!this.options['install-deps'],
         testDir: fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests',

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 
 test('should generate a project in the current directory', async ({ run, packageManager }) => {
   test.slow();
-  const { exitCode, dir, stdout } = await run([], { installGitHubActions: true, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
+  const { exitCode, dir, stdout } = await run([], { installGitHubActions: true, generatePomTest: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(exitCode).toBe(0);
   expect(fs.existsSync(path.join(dir, 'tests/example.spec.ts'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
@@ -48,7 +48,7 @@ test('should generate a project in the current directory', async ({ run, package
 });
 
 test('should generate a project in a given directory', async ({ run, packageManager }) => {
-  const { exitCode, dir } = await run(['foobar'], { installGitHubActions: true, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
+  const { exitCode, dir } = await run(['foobar'], { installGitHubActions: true, generatePomTest: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(exitCode).toBe(0);
   expect(fs.existsSync(path.join(dir, 'foobar/tests/example.spec.ts'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'foobar/package.json'))).toBeTruthy();
@@ -63,7 +63,7 @@ test('should generate a project in a given directory', async ({ run, packageMana
 });
 
 test('should generate a project with JavaScript and without GHA', async ({ run, packageManager }) => {
-  const { exitCode, dir } = await run([], { installGitHubActions: false, testDir: 'tests', language: 'JavaScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
+  const { exitCode, dir } = await run([], { installGitHubActions: false, generatePomTest: false, testDir: 'tests', language: 'JavaScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(exitCode).toBe(0);
   expect(fs.existsSync(path.join(dir, 'tests/example.spec.js'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
@@ -79,7 +79,7 @@ test('should generate a project with JavaScript and without GHA', async ({ run, 
 
 test('should generate be able to run TS examples successfully', async ({ run, packageManager }) => {
   test.slow();
-  const { exitCode, dir, exec } = await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
+  const { exitCode, dir, exec } = await run([], { installGitHubActions: false, generatePomTest: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(exitCode).toBe(0);
   expect(fs.existsSync(path.join(dir, 'tests/example.spec.ts'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
@@ -96,7 +96,7 @@ test('should generate be able to run TS examples successfully', async ({ run, pa
 
 test('should generate be able to run JS examples successfully', async ({ run, packageManager }) => {
   test.slow();
-  const { exitCode, dir, exec } = await run([], { installGitHubActions: false, testDir: 'tests', language: 'JavaScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
+  const { exitCode, dir, exec } = await run([], { installGitHubActions: false, generatePomTest: false, testDir: 'tests', language: 'JavaScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(exitCode).toBe(0);
   expect(fs.existsSync(path.join(dir, 'tests/example.spec.js'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();


### PR DESCRIPTION
add `Generate Page-Object-Model test example` based on https://playwright.dev/docs/pom 

- `JavaScript`

https://user-images.githubusercontent.com/6134774/199937856-d9a088e1-bb9c-4be2-b099-c3918a259ed8.mov

- `TypeScript`

https://user-images.githubusercontent.com/6134774/199937952-d5093769-b061-47af-aebd-f6afbcda42b3.mov

- `npm run test`

![Screen Shot 2022-11-04 at 16 50 19](https://user-images.githubusercontent.com/6134774/199943904-d565a8e3-752f-4b86-9066-478bfabe4d09.png)
