### PR TITLE
chore: update examples

### DIFF
--- a/assets/example.spec.js
+++ b/assets/example.spec.js
@@ -1,21 +1,19 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
-test('homepage has title and links to intro page', async ({ page }) => {
+test('has title', async ({ page }) => {
   await page.goto('https://playwright.dev/');
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
+});
 
-  // create a locator
-  const getStarted = page.getByRole('link', { name: 'Get started' });
-
-  // Expect an attribute "to be strictly equal" to the value.
-  await expect(getStarted).toHaveAttribute('href', '/docs/intro');
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
 
   // Click the get started link.
-  await getStarted.click();
-  
+  await page.getByRole('link', { name: 'Get started' }).click();
+
   // Expects the URL to contain intro.
   await expect(page).toHaveURL(/.*intro/);
 });

--- a/assets/example.spec.ts
+++ b/assets/example.spec.ts
@@ -1,19 +1,17 @@
 import { test, expect } from '@playwright/test';
 
-test('homepage has title and links to intro page', async ({ page }) => {
+test('has title', async ({ page }) => {
   await page.goto('https://playwright.dev/');
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
+});
 
-  // create a locator
-  const getStarted = page.getByRole('link', { name: 'Get started' });
-
-  // Expect an attribute "to be strictly equal" to the value.
-  await expect(getStarted).toHaveAttribute('href', '/docs/intro');
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
 
   // Click the get started link.
-  await getStarted.click();
+  await page.getByRole('link', { name: 'Get started' }).click();
 
   // Expects the URL to contain intro.
   await expect(page).toHaveURL(/.*intro/);


### PR DESCRIPTION
update examples to align with new docs example just released: 
https://playwright.dev/docs/writing-tests