### PR TITLE
Use pnpm exec instead of pnpm dlx

### DIFF
--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -67,7 +67,7 @@ class PNPM implements PackageManager {
   }
 
   npx(command: string, args: string): string {
-    return `pnpm dlx ${command} ${args}`
+    return `pnpm exec ${command} ${args}`
   }
 
   ci(): string {


### PR DESCRIPTION
Whether to run `pnpm dlx` or `pnpm exec` should depend on whether to run the package from the registry or from local `node_modules`:

- [`pnpm dlx`](https://pnpm.io/cli/dlx) will always download from the npm registry
- [`pnpm exec`](https://pnpm.io/cli/exec) will run the package from `node_modules`

(In contrary, npm’s `npx` will run the package from local `node_modules` if it exists, only install otherwise. This is not the behavior of `pnpm dlx`.)

So it should be something like this:

- Use `pnpm dlx` to run `create-playwright`
- Use `pnpm exec` to run `playwright`