### PR TITLE
chore: update examples

### DIFF
--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -71,7 +71,7 @@ module.exports = defineConfig({
     // },
     // {
     //   name: 'Google Chrome',
-    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
   ],
 

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -70,7 +70,7 @@ export default defineConfig({
     // },
     // {
     //   name: 'Google Chrome',
-    //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
   ],
 


### PR DESCRIPTION
Fix the error in the examples config for `Google Chrome`.