### PR TITLE
chore: align example.spec with new upstream default

### DIFF
--- a/assets/example.spec.js
+++ b/assets/example.spec.js
@@ -14,6 +14,6 @@ test('get started link', async ({ page }) => {
   // Click the get started link.
   await page.getByRole('link', { name: 'Get started' }).click();
 
-  // Expects the URL to contain intro.
-  await expect(page).toHaveURL(/.*intro/);
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
 });

--- a/assets/example.spec.ts
+++ b/assets/example.spec.ts
@@ -13,6 +13,6 @@ test('get started link', async ({ page }) => {
   // Click the get started link.
   await page.getByRole('link', { name: 'Get started' }).click();
 
-  // Expects the URL to contain intro.
-  await expect(page).toHaveURL(/.*intro/);
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
 });


### PR DESCRIPTION
Fixes https://github.com/microsoft/create-playwright/issues/93