### PR TITLE
docs: `pnpm` usage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ npm init playwright@latest
 # Or for Yarn
 yarn create playwright
 # Or for pnpm
-pnpm dlx create-playwright
+pnpm create playwright
 ```


### PR DESCRIPTION
`pnpm` has the [same API](https://pnpm.io/cli/create) as yarn: `pnpm create`