### PR TITLE
feat: add blob-report to gitignore

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -250,6 +250,7 @@ export class Generator {
       gitIgnore += 'node_modules/\n';
     gitIgnore += '/test-results/\n';
     gitIgnore += '/playwright-report/\n';
+    gitIgnore += '/blob-report/\n';
     gitIgnore += '/playwright/.cache/\n';
     fs.writeFileSync(gitIgnorePath, gitIgnore);
   }


### PR DESCRIPTION
The Playwright v1.37 introduces the new `merge-reports` command.
This uses blob files created within the `blob-reports` directory, but this directory is not included within the gitignore file, and will be committed to git when you're not paying attention to it.

This PR adds the `blob-reports` directory to the gitignore file.