### PR TITLE
feat: handle disabled lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.44.1",
+        "@types/ini": "^4.1.1",
         "@types/node": "^18.19.33",
         "ansi-colors": "^4.1.1",
         "enquirer": "^2.3.6",
         "esbuild": "^0.14.25",
+        "ini": "^4.1.3",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -37,6 +39,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.19.33",
@@ -437,6 +445,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.44.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
@@ -496,6 +513,12 @@
       "requires": {
         "playwright": "1.44.1"
       }
+    },
+    "@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.19.33",
@@ -695,6 +718,12 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true
     },
     "playwright": {
       "version": "1.44.1",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",
+    "@types/ini": "^4.1.1",
     "@types/node": "^18.19.33",
     "ansi-colors": "^4.1.1",
     "enquirer": "^2.3.6",
     "esbuild": "^0.14.25",
+    "ini": "^4.1.3",
     "typescript": "^5.4.5"
   }
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 
 import { prompt } from 'enquirer';
 import colors from 'ansi-colors';
+import ini from 'ini';
 
 import { executeCommands, createFiles, executeTemplate, Command, languageToFileExtension, getFileExtensionCT } from './utils';
 import { type PackageManager, determinePackageManager } from './packageManager';
@@ -174,8 +175,10 @@ export class Generator {
     }
 
     if (answers.installGitHubActions) {
+      const npmrcExists = fs.existsSync(path.join(this.rootDir, '.npmrc'));
+      const packageLockDisabled = npmrcExists && ini.parse(fs.readFileSync(path.join(this.rootDir, '.npmrc'), 'utf-8'))['package-lock'] === false;
       const githubActionsScript = executeTemplate(this._readAsset('github-actions.yml'), {
-        installDepsCommand: this.packageManager.ci(),
+        installDepsCommand: packageLockDisabled ? this.packageManager.i() : this.packageManager.ci(),
         installPlaywrightCommand: this.packageManager.npx('playwright', 'install --with-deps'),
         runTestsCommand: answers.framework ? this.packageManager.run('test-ct') : this.packageManager.runPlaywrightTest(),
       }, new Map());

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -7,6 +7,7 @@ export interface PackageManager {
   init(): string
   npx(command: string, args: string): string
   ci(): string
+  i(): string
   installDevDependency(name: string): string
   runPlaywrightTest(args?: string): string
   run(script: string): string
@@ -26,6 +27,10 @@ class NPM implements PackageManager {
 
   ci(): string {
     return 'npm ci'
+  }
+
+  i(): string {
+    return 'npm i'
   }
 
   installDevDependency(name: string): string {
@@ -55,6 +60,10 @@ class Yarn implements PackageManager {
 
   ci(): string {
     return 'npm install -g yarn && yarn'
+  }
+
+  i(): string {
+    return this.ci()
   }
 
   installDevDependency(name: string): string {
@@ -87,6 +96,10 @@ class PNPM implements PackageManager {
 
   ci(): string {
     return 'npm install -g pnpm && pnpm install'
+  }
+
+  i(): string {
+    return this.ci()
   }
 
   installDevDependency(name: string): string {


### PR DESCRIPTION
When initializing playwright in an existing project, the CLI miss `package-lock=false` in the .npmrc (if exists).

`npm ci` is not compatible without lockfile, this PR fixes it: when package-lock.json is disabled, replaces `npm ci` with `npm i` in the workflow.

