### PR TITLE
fix: exit with return code 0, exit early with --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,11 +34,11 @@ import { Generator } from './generator';
     else
       options[name] = [];
   }
-  const rootDir = path.resolve(process.cwd(), args[0] || '');
   if (options.help) {
     _printHelp();
-    process.exit(1);
+    process.exit(0);
   }
+  const rootDir = path.resolve(process.cwd(), args[0] || '');
   const generator = new Generator(rootDir, options);
   await generator.run();
 })().catch(error => {


### PR DESCRIPTION
Hi there, I was reading the code for the `--help` flag and I realized that `create-playwright` is:

1. Exiting with a non-zero exit code
2. Doing some work to find the root directory and then throwing that away

Both of these seem like unusual patterns.

Some basis for the return code 0 change here:

- https://stackoverflow.com/questions/50565408/should-bash-scripts-called-with-help-argument-return-0-or-not-zero-exit-code