### PR TITLE
fix: don't duplicate `.gitignore` entries

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -273,7 +273,7 @@ export class Generator {
       gitIgnore = fs.readFileSync(gitIgnorePath, 'utf-8').trimEnd() + '\n';
     const valuesToAdd = { 
       'node_modules/': /^node_modules\/?/m,
-      '/test-results/': /^test-results\/?$/m,
+      '/test-results/': /^\/?test-results\/?$/m,
       '/playwright-report/': /^\/playwright-report\/?$/m,
       '/blob-report/': /^\/blob-report\/?$/m,
       '/playwright/.cache/': /^\/playwright\/\.cache\/?$/m

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -258,12 +258,12 @@ export class Generator {
     let gitIgnore = '';
     if (fs.existsSync(gitIgnorePath))
       gitIgnore = fs.readFileSync(gitIgnorePath, 'utf-8').trimEnd() + '\n';
-    if (!gitIgnore.includes('node_modules'))
-      gitIgnore += 'node_modules/\n';
-    gitIgnore += '/test-results/\n';
-    gitIgnore += '/playwright-report/\n';
-    gitIgnore += '/blob-report/\n';
-    gitIgnore += '/playwright/.cache/\n';
+    const valuesToAdd = ['node_modules/', '/test-results/', '/playwright-report/', '/blob-report/', '/playwright/.cache/'];
+    valuesToAdd.forEach(value => {
+      if (!gitIgnore.includes(value)) {
+        gitIgnore += `${value}\n`;
+      }
+    });
     fs.writeFileSync(gitIgnorePath, gitIgnore);
   }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -258,9 +258,15 @@ export class Generator {
     let gitIgnore = '';
     if (fs.existsSync(gitIgnorePath))
       gitIgnore = fs.readFileSync(gitIgnorePath, 'utf-8').trimEnd() + '\n';
-    const valuesToAdd = ['node_modules/', '/test-results/', '/playwright-report/', '/blob-report/', '/playwright/.cache/'];
-    valuesToAdd.forEach(value => {
-      if (!gitIgnore.includes(value)) {
+    const valuesToAdd = { 
+      'node_modules/': /^\node_modules\/?/m,
+      '/test-results/': /^\test-results\/?$/m,
+      '/playwright-report/': /^\/playwright-report\/$/m,
+      '/blob-report/': /^\/blob-report\//m,
+      '/playwright/.cache/': /^\/playwright\/\.cache\//m
+    };
+    Object.entries(valuesToAdd).forEach(([value, regex]) => {
+      if (!gitIgnore.match(regex)) {
         gitIgnore += `${value}\n`;
       }
     });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -259,11 +259,11 @@ export class Generator {
     if (fs.existsSync(gitIgnorePath))
       gitIgnore = fs.readFileSync(gitIgnorePath, 'utf-8').trimEnd() + '\n';
     const valuesToAdd = { 
-      'node_modules/': /^\node_modules\/?/m,
-      '/test-results/': /^\test-results\/?$/m,
-      '/playwright-report/': /^\/playwright-report\/$/m,
-      '/blob-report/': /^\/blob-report\//m,
-      '/playwright/.cache/': /^\/playwright\/\.cache\//m
+      'node_modules/': /^node_modules\/?/m,
+      '/test-results/': /^test-results\/?$/m,
+      '/playwright-report/': /^\/playwright-report\/?$/m,
+      '/blob-report/': /^\/blob-report\/?$/m,
+      '/playwright/.cache/': /^\/playwright\/\.cache\/?$/m
     };
     Object.entries(valuesToAdd).forEach(([value, regex]) => {
       if (!gitIgnore.match(regex)) {

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -19,7 +19,7 @@ import fs from 'fs';
 import childProcess from 'child_process';
 
 const validGitignore = [
-  'node_modules',
+  'node_modules/',
   '/test-results/',
   '/playwright-report/',
   '/blob-report/',

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -18,7 +18,13 @@ import path from 'path';
 import fs from 'fs';
 import childProcess from 'child_process';
 
-const validGitignore = 'node_modules/\n/test-results/\n/playwright-report/\n/blob-report/\n/playwright/.cache/\n';
+const validGitignore = [
+  'node_modules',
+  '/test-results/',
+  '/playwright-report/',
+  '/blob-report/',
+  '/playwright/.cache/',
+].join('\n');
 
 test('should generate a project in the current directory', async ({ run, dir, packageManager }) => {
   test.slow();
@@ -106,8 +112,7 @@ test('should generate in the root of pnpm workspace', async ({ run, packageManag
 });
 
 test('should not duplicate gitignore entries', async ({ run, dir }) => {
-  await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
-  expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' })).toMatch(validGitignore);
+  fs.writeFileSync(path.join(dir, '.gitignore'), validGitignore);
 
   await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
   expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' })).toMatch(validGitignore);

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -37,7 +37,7 @@ test('should generate a project in the current directory', async ({ run, dir, pa
   expect(playwrightConfigContent).toContain('tests');
   expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, '.gitignore'))).toBeTruthy();
-  expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' })).toMatch(validGitignore);
+  expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' }).trim()).toBe(validGitignore);
   if (packageManager === 'npm') {
     expect(stdout).toContain('Initializing NPM project (npm init -y)…');
     expect(stdout).toContain('Installing Playwright Test (npm install --save-dev @playwright/test)…');
@@ -115,7 +115,7 @@ test('should not duplicate gitignore entries', async ({ run, dir }) => {
   fs.writeFileSync(path.join(dir, '.gitignore'), validGitignore);
 
   await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
-  expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' })).toMatch(validGitignore);
+  expect(fs.readFileSync(path.join(dir, '.gitignore'), { encoding: 'utf8' }).trim()).toBe(validGitignore);
 })
 
 test('should install with "npm ci" in GHA when using npm with package-lock enabled', async ({ dir, run, packageManager }) => {


### PR DESCRIPTION
## Description

This PR fixes the duplication of existing `.gitignore` entries while running `npm create playwright`. 

Although this only occurs when the command is run more than once, the added entries don't need to be duplicated. 

Related to https://github.com/microsoft/playwright/issues/31021