### PR TITLE
chore: absolute dotenv path import

### DIFF
--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -5,7 +5,7 @@ const { defineConfig, devices } = require('@playwright/test');
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+// require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * @see https://playwright.dev/docs/test-configuration

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -4,7 +4,8 @@ import { defineConfig, devices } from '@playwright/test';
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+// import dotenv from 'dotenv';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
https://github.com/microsoft/playwright/issues/31145

The default is `Default: path.resolve(process.cwd(), '.env')` which is a problem for us in monorepo scenarios.