### PR TITLE
Use `'github'` reporter when `GITHUB_ACTIONS` set

### DIFF
--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -21,9 +21,7 @@ module.exports = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.GITHUB_ACTIONS
-    ? 'github'
-    : 'html',
+  reporter: process.env.GITHUB_ACTIONS ? 'github' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -21,7 +21,9 @@ module.exports = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.GITHUB_ACTIONS
+    ? 'github'
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.GITHUB_ACTIONS
+    ? 'github'
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -22,9 +22,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.GITHUB_ACTIONS
-    ? 'github'
-    : 'html',
+  reporter: process.env.GITHUB_ACTIONS ? 'github' : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
When [`process.env.GITHUB_ACTIONS`](https://docs.github.com/en/actions/learn-github-actions/variables#:~:text=GITHUB_ACTIONS,by%20GitHub%20Actions.) is set, use [the `'github'` reporter](https://playwright.dev/docs/test-reporters#github-actions-annotations)