### PR TITLE
fix: correct repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-playwright",
   "version": "1.17.133",
   "description": "Getting started with writing end-to-end tests with Playwright.",
-  "repository": "github:Microsoft/playwright",
+  "repository": "github:Microsoft/create-playwright",
   "homepage": "https://playwright.dev",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
The current link to the github repo in the package.json is incorrect, which makes it easier to find the source code for the package. This PR fixes it