### PR TITLE
Add --no-gha option to skip GitHub Actions workflow

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,8 @@ function _printHelp() {
       --beta: install @beta version of Playwright
       --ct: install Playwright Component testing
       --quiet: do not ask for interactive input prompts
-      --gha: install GitHub Actions
+      --gha: create GitHub Actions workflow
+      --no-gha: do not create GitHub Actions workflow
       --lang=<js>: language to use (default: 'TypeScript'. Potential values: 'js', 'TypeScript')
     `);
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -42,6 +42,7 @@ type CliArgumentKey = 'browser'
   | 'ct'
   | 'quiet'
   | 'gha'
+  | 'no-gha'
   | 'install-deps'
   | 'lang';
 
@@ -129,8 +130,9 @@ export class Generator {
         type: 'confirm',
         name: 'installGitHubActions',
         message: 'Add a GitHub Actions workflow?',
-        initial: !!this.options.gha,
-        skip: !!this.options.gha,
+        // Default to false, even when --no-gha not passed
+        initial: !!this.options['no-gha'] ? false : !!this.options.gha,
+        skip: !!this.options['no-gha'] || !!this.options.gha,
       },
       {
         type: 'confirm',


### PR DESCRIPTION
Add `--no-gha` option to be able to skip the question of creating the GitHub Actions workflow

```bash
➜  a pnpm create playwright
Getting started with writing end-to-end tests with Playwright:
Initializing project in '.'
✔ Dou you want to use TypeScript or JavaScript? · TypeScript
✔ Where to put your end-to-end tests? · tests
✖ Add a GitHub Actions workflow? (y/N) · false

➜  a pnpm create playwright --no-gha
Getting started with writing end-to-end tests with Playwright:
Initializing project in '.'
✔ Dou you want to use TypeScript or JavaScript? · TypeScript
✔ Where to put your end-to-end tests? · tests
✖ Install Playwright browsers (can be done manually via 'pnpm exec playwright install')? (Y/n) · true
```