### PR TITLE
chore: use import instead of require in generated JS examples

### DIFF
--- a/assets/demo-todo-app.spec.js
+++ b/assets/demo-todo-app.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
+import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('https://demo.playwright.dev/todomvc');

--- a/assets/example.spec.js
+++ b/assets/example.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
+import { test, expect } from '@playwright/test';
 
 test('has title', async ({ page }) => {
   await page.goto('https://playwright.dev/');

--- a/assets/playwright-ct.config.js
+++ b/assets/playwright-ct.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { defineConfig, devices } = require('{{ctPackageName}}');
+import { defineConfig, devices } from '{{ctPackageName}}';
 
 /**
  * @see https://playwright.dev/docs/test-configuration

--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -1,16 +1,18 @@
 // @ts-check
-const { defineConfig, devices } = require('@playwright/test');
+import { defineConfig, devices } from '@playwright/test';
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config({ path: path.resolve(__dirname, '.env') });
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
-module.exports = defineConfig({
+export default defineConfig({
   testDir: './{{testDir}}',
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
We transform everything which allows us to use `import` in JS files. This means we don't need to feature detect esm/cjs on the create-playwright side and can emit `import` all the time.

This follows our strategy to only show TS examples in the docs, since they match JS in most of the cases % types.

Closes https://github.com/microsoft/playwright/issues/33238