### PR TITLE
chore: replace old ansi-colors with modern, smaller and faster ansis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "create-playwright": "index.js"
       },
       "devDependencies": {
-        "@playwright/test": "^1.44.1",
+        "@playwright/test": "^1.49.0",
         "@types/ini": "^4.1.1",
         "@types/node": "^18.19.33",
-        "ansi-colors": "^4.1.1",
+        "ansis": "^3.3.2",
         "enquirer": "^2.3.6",
         "esbuild": "^0.14.25",
         "ini": "^4.1.3",
@@ -26,18 +26,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.44.1"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@types/ini": {
@@ -62,6 +63,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=15"
       }
     },
     "node_modules/enquirer": {
@@ -437,6 +448,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -455,33 +467,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -506,12 +520,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "dev": true,
       "requires": {
-        "playwright": "1.44.1"
+        "playwright": "1.49.0"
       }
     },
     "@types/ini": {
@@ -533,6 +547,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansis": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.3.2.tgz",
+      "integrity": "sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==",
       "dev": true
     },
     "enquirer": {
@@ -726,19 +746,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.49.0"
       }
     },
     "playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "@playwright/test": "^1.44.1",
+    "@playwright/test": "^1.49.0",
     "@types/ini": "^4.1.1",
     "@types/node": "^18.19.33",
-    "ansi-colors": "^4.1.1",
+    "ansis": "^3.3.2",
     "enquirer": "^2.3.6",
     "esbuild": "^0.14.25",
     "ini": "^4.1.3",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -16,7 +16,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import colors from 'ansi-colors';
+import { cyan, green, yellow, bold } from 'ansis';
 import { prompt } from 'enquirer';
 import ini from 'ini';
 
@@ -74,7 +74,7 @@ export class Generator {
   }
 
   private _printPrologue() {
-    console.log(colors.yellow(`Getting started with writing ${colors.bold('end-to-end')} tests with ${colors.bold('Playwright')}:`));
+    console.log(yellow`Getting started with writing ${bold`end-to-end`} tests with ${bold`Playwright`}:`);
     console.log(`Initializing project in '${path.relative(process.cwd(), this.rootDir) || '.'}'`);
   }
 
@@ -314,7 +314,7 @@ export class Generator {
   }
 
   private _printEpilogue(answers: PromptOptions) {
-    console.log(colors.green('✔ Success!') + ' ' + colors.bold(`Created a Playwright Test project at ${this.rootDir}`));
+    console.log(green`✔ Success!` + ' ' + bold`Created a Playwright Test project at ${this.rootDir}`);
     const pathToNavigate = path.relative(process.cwd(), this.rootDir);
     const prefix = pathToNavigate !== '' ? `  cd ${pathToNavigate}\n` : '';
     const exampleSpecPath = path.join(answers.testDir, `example.spec.${languageToFileExtension(answers.language)}`);
@@ -323,27 +323,27 @@ export class Generator {
     console.log(`
 Inside that directory, you can run several commands:
 
-  ${colors.cyan(this.packageManager.runPlaywrightTest())}
+  ${cyan(this.packageManager.runPlaywrightTest())}
     Runs the end-to-end tests.
 
-  ${colors.cyan(this.packageManager.runPlaywrightTest('--ui'))}
+  ${cyan(this.packageManager.runPlaywrightTest('--ui'))}
     Starts the interactive UI mode.
 
-  ${colors.cyan(this.packageManager.runPlaywrightTest('--project=chromium'))}
+  ${cyan(this.packageManager.runPlaywrightTest('--project=chromium'))}
     Runs the tests only on Desktop Chrome.
 
-  ${colors.cyan(this.packageManager.runPlaywrightTest('example'))}
+  ${cyan(this.packageManager.runPlaywrightTest('example'))}
     Runs the tests in a specific file.
 
-  ${colors.cyan(this.packageManager.runPlaywrightTest('--debug'))}
+  ${cyan(this.packageManager.runPlaywrightTest('--debug'))}
     Runs the tests in debug mode.
 
-  ${colors.cyan(this.packageManager.npx('playwright', 'codegen'))}
+  ${cyan(this.packageManager.npx('playwright', 'codegen'))}
     Auto generate tests with Codegen.
 
 We suggest that you begin by typing:
 
-  ${colors.cyan(prefix + '  ' + this.packageManager.runPlaywrightTest())}
+  ${cyan(prefix + '  ' + this.packageManager.runPlaywrightTest())}
 
 And check out the following files:
   - .${path.sep}${pathToNavigate ? path.join(pathToNavigate, exampleSpecPath) : exampleSpecPath} - Example end-to-end test
@@ -356,25 +356,25 @@ Happy hacking! 🎭`);
   }
 
   private _printEpilogueCT() {
-    console.log(colors.green('✔ Success!') + ' ' + colors.bold(`Created a Playwright Test project at ${this.rootDir}`));
+    console.log(green`✔ Success!` + ' ' + bold`Created a Playwright Test project at ${this.rootDir}`);
     console.log(`
 Inside that directory, you can run several commands:
 
-  ${colors.cyan(`${this.packageManager.cli} run test-ct`)}
+  ${cyan(`${this.packageManager.cli} run test-ct`)}
     Runs the component tests.
 
-  ${colors.cyan(`${this.packageManager.cli} run test-ct -- --project=chromium`)}
+  ${cyan(`${this.packageManager.cli} run test-ct -- --project=chromium`)}
     Runs the tests only on Desktop Chrome.
 
-  ${colors.cyan(`${this.packageManager.cli} run test-ct App.test.ts`)}
+  ${cyan(`${this.packageManager.cli} run test-ct App.test.ts`)}
     Runs the tests in the specific file.
 
-  ${colors.cyan(`${this.packageManager.cli} run test-ct -- --debug`)}
+  ${cyan(`${this.packageManager.cli} run test-ct -- --debug`)}
     Runs the tests in debug mode.
 
 We suggest that you begin by typing:
 
-  ${colors.cyan(`${this.packageManager.cli} run test-ct`)}
+  ${cyan(`${this.packageManager.cli} run test-ct`)}
 
 Visit https://playwright.dev/docs/intro for more information. ✨
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ import { execSync } from 'child_process';
 import path from 'path';
 
 import { prompt } from 'enquirer';
-import colors from 'ansi-colors';
+import { gray } from 'ansis';
 import { PromptOptions } from './generator';
 
 export type Command = {
@@ -50,7 +50,7 @@ export async function createFiles(rootDir: string, files: Map<string, string>, f
       if (!override)
         continue;
     }
-    console.log(colors.gray(`Writing ${path.relative(process.cwd(), absoluteFilePath)}.`));
+    console.log(gray`Writing ${path.relative(process.cwd(), absoluteFilePath)}.`);
     fs.mkdirSync(path.dirname(absoluteFilePath), { recursive: true });
     fs.writeFileSync(absoluteFilePath, value, 'utf-8');
   }


### PR DESCRIPTION
Hello,

This PR replaces the [ansi-colors](https://github.com/doowb/ansi-colors) package with smaller, faster and TypeScript-friendly [ansis](https://github.com/webdiscus/ansis).

## Why switch to another package?

- The `ansi-colors` package has not been maintained for more than 3 years!
  It's time to switch to another modern and powerful package with long-term support, such as `ansis`.
- `ansis` allows to import color names and avoid nested parentheses, that makes the code much cleaner and more readable:
  ```js
  - console.log(colors.yellow(`Getting started with writing ${colors.bold('end-to-end')} tests with ${colors.bold('Playwright')}:`));
  + console.log(yellow`Getting started with writing ${bold`end-to-end`} tests with ${bold`Playwright`}:`);
  ```
- `ansis` is much easier and more comfortable to use than `ansi-colors`. Just try it!

### Benefits of `ansis`

- Installed package size is smaller: ansis `11 KB` vs ansi-colors `26 KB`. See [Compare the sizes of most popular packages](https://github.com/webdiscus/ansis#compare-size)
- `ansis` is smaller but has more features. See [compare features](https://github.com/webdiscus/ansis#compare)
- 5x faster than `ansi-colors`. See [benchmarks](https://github.com/webdiscus/ansis#benchmark)
- Supports `Bun` and `Deno` runtimes
- [Fallback](https://github.com/webdiscus/ansis#fallback) to supported color space: TrueColor → 256 colors → 16 colors → no colors
- Supports [environment variables](https://github.com/webdiscus/ansis#cli-vars) `NO_COLOR` `FORCE_COLOR` and flags `--no-color` `--color`
- Supports [named import](https://github.com/webdiscus/ansis#named-import)  `import { red, green, bold, ansi256, hex } from 'ansis'`
- [Nested template strings](https://github.com/webdiscus/ansis#nested-syntax) ``` red`ERROR: ${blue`file.js`} not found!` ```
- TypeScript-friendly
- Test coverage 100%

### Packages that already use `ansis`

- [facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json)
- [nestjs/nest](https://github.com/nestjs/nest/blob/master/package.json)
- [sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json)
- [oclif/core](https://github.com/oclif/core/blob/prerelease/beta/package.json)
- [salesforcecli/cli](https://github.com/salesforcecli/cli/blob/main/package.json)
- [grafana/faro-javascript-bundler-plugins](https://github.com/grafana/faro-javascript-bundler-plugins/blob/main/packages/faro-bundlers-shared/package.json)
- and [thousands others](https://github.com/webdiscus/ansis/network/dependents)

## Test

This PR does not require unit/integration tests.

But you can do the `manual test`:

```
git clone https://github.com/webdiscus/ansis-create-playwright.git
cd ansis-create-playwright
git checkout switch-to-ansis
npm i
npm run build
```

### Test color output in console - `node ./index.js`:

![image](https://github.com/user-attachments/assets/a12079df-1b62-4ad3-ace5-18cfab1d0f96)

### Test no color output in console - `node ./index.js --no-color`:

![image](https://github.com/user-attachments/assets/98c4001f-9688-4a2a-9c18-037843a370db)