### PR TITLE
test: execute one yarn after another

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
     - run: npx playwright install-deps
     - run: npm run build
     - run: npx tsc --noEmit
-    - run: npm run test -- --project=npm --project=pnpm --project=yarn-classic
+    - run: npm run test -- --grep-invert yarn-berry
     - run: yarn set version stable
-    - run: npm run test -- --project=yarn-berry
+    - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm i -g yarn@latest
     - run: npm i -g yarn@1
     - run: npm i -g pnpm@8
     - run: npm ci
     - run: npx playwright install-deps
     - run: npm run build
     - run: npx tsc --noEmit
-    - run: npm run test
+    - run: npm run test -- --project=npm --project=pnpm --project=yarn-classic
+    - run: yarn set version stable
+    - run: npm run test -- --project=yarn-berry

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,13 +35,13 @@ export default defineConfig<TestFixtures>({
     {
       name: 'yarn-classic',
       use: {
-        packageManager: 'npx yarn@1'
+        packageManager: 'yarn-classic'
       }
     },
     {
-      name: 'yarn',
+      name: 'yarn-berry',
       use: {
-        packageManager: 'yarn'
+        packageManager: 'yarn-berry'
       }
     },
     {

--- a/tests/baseFixtures.ts
+++ b/tests/baseFixtures.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import fs from 'fs';
 import type { PromptOptions } from '../src/generator';
 
-export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'npx yarn@1';
+export type PackageManager = 'npm' | 'pnpm' | 'yarn-classic' | 'yarn-berry';
 
 export type TestFixtures = {
   packageManager: PackageManager;
@@ -82,7 +82,7 @@ export const test = base.extend<TestFixtures>({
         cwd: dir,
         env: {
           ...process.env,
-          'npm_config_user_agent': packageManager === 'yarn' ? 'yarn' : packageManager === 'pnpm' ? 'pnpm/0.0.0' : undefined,
+          'npm_config_user_agent': packageManager.startsWith('yarn') ? 'yarn' : packageManager === 'pnpm' ? 'pnpm/0.0.0' : undefined,
           'TEST_OPTIONS': JSON.stringify(options),
         },
       });
@@ -94,7 +94,7 @@ export function assertLockFilesExist(dir: string, packageManager: PackageManager
   expect(fs.existsSync(path.join(dir, 'package.json'))).toBeTruthy();
   if (packageManager === 'npm')
     expect(fs.existsSync(path.join(dir, 'package-lock.json'))).toBeTruthy();
-  else if (packageManager === 'yarn')
+  else if (packageManager.startsWith('yarn'))
     expect(fs.existsSync(path.join(dir, 'yarn.lock'))).toBeTruthy();
   else if (packageManager === 'pnpm')
     expect(fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))).toBeTruthy();
@@ -104,10 +104,9 @@ export function packageManagerToNpxCommand(packageManager: PackageManager): stri
   switch (packageManager) {
     case 'npm':
       return 'npx';
-    case 'yarn':
+    case 'yarn-classic':
+    case 'yarn-berry':
       return 'yarn';
-    case 'npx yarn@1':
-      return 'npx yarn@1';
     case 'pnpm':
       return 'pnpm dlx';
   }

--- a/tests/component-testing.spec.ts
+++ b/tests/component-testing.spec.ts
@@ -18,7 +18,7 @@ import path from 'path';
 import fs from 'fs';
 
 test('should be able to generate and run a CT React project', async ({ run, dir, exec, packageManager }) => {
-  test.skip(packageManager === 'yarn');
+  test.skip(packageManager === 'yarn-classic' || packageManager === 'yarn-berry');
   test.slow();
   await run(['--ct'], { installGitHubActions: true, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true, framework: 'react' });
   {
@@ -32,7 +32,7 @@ test('should be able to generate and run a CT React project', async ({ run, dir,
     expect(fs.readFileSync(path.join(dir, '.github/workflows/playwright.yml'), 'utf8')).toContain('test-ct');
   }
 
-  await exec(packageManager, [(packageManager === 'yarn' ? 'add' : 'install'), 'react', 'react-dom']);
+  await exec(packageManager, [((packageManager === 'yarn-classic' || packageManager === 'yarn-berry') ? 'add' : 'install'), 'react', 'react-dom']);
 
   fs.mkdirSync(path.join(dir, 'src'));
   fs.writeFileSync(path.join(dir, 'src/App.tsx'), 'export default () => <>Learn React</>;');

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -115,7 +115,7 @@ test('should generate in the root of pnpm workspace', async ({ run, packageManag
 });
 
 test('should generate in the root of yarn workspaces', async ({ run, packageManager }) => {
-  test.skip(packageManager !== 'npx yarn@1');
+  test.skip(packageManager !== 'yarn-classic');
 
   const dir = test.info().outputDir;
   fs.mkdirSync(dir, { recursive: true });
@@ -167,4 +167,14 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
   const workflowContent = fs.readFileSync(path.join(dir, '.github/workflows/playwright.yml'), 'utf8');
   expect(workflowContent).toContain('run: npm i');
   expect(workflowContent).not.toContain('run: npm ci');
+});
+
+test('is proper yarn classic', async ({ packageManager }) => {
+  test.skip(packageManager !== 'yarn-classic');
+  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8' })).toMatch(/^1\./);
+});
+
+test('is proper yarn berry', async ({ packageManager }) => {
+  test.skip(packageManager !== 'yarn-berry');
+  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8' })).toMatch(/^4\./);
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -128,9 +128,9 @@ test('should generate in the root of yarn workspaces', async ({ run, packageMana
   for (const pkg of ['foo', 'bar']) {
     const packageDir = path.join(dir, 'packages', pkg);
     fs.mkdirSync(packageDir, { recursive: true });
-    childProcess.execSync(`${packageManager} init -y`, { cwd: packageDir });
+    childProcess.execSync(`yarn init -y`, { cwd: packageDir });
   }
-  childProcess.execSync(`${packageManager} install`, { cwd: dir });
+  childProcess.execSync(`yarn install`, { cwd: dir });
 
   await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
   assertLockFilesExist(dir, packageManager);

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -28,7 +28,7 @@ const validGitignore = [
 ].join('\n');
 
 test('should generate a project in the current directory', async ({ run, dir, packageManager }) => {
-  test.skip(packageManager === 'yarn');
+  test.skip(packageManager === 'yarn-classic' || packageManager === 'yarn-berry');
   test.slow();
   const { stdout } = await run([], { installGitHubActions: true, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(fs.existsSync(path.join(dir, 'tests/example.spec.ts'))).toBeTruthy();
@@ -44,7 +44,7 @@ test('should generate a project in the current directory', async ({ run, dir, pa
     expect(stdout).toContain('Initializing NPM project (npm init -y)…');
     expect(stdout).toContain('Installing Playwright Test (npm install --save-dev @playwright/test)…');
     expect(stdout).toContain('Installing Types (npm install --save-dev @types/node)…');
-  } else if (packageManager === 'yarn') {
+  } else if (packageManager === 'yarn-classic') {
     expect(stdout).toContain('Initializing Yarn project (yarn init -y)…');
     expect(stdout).toContain('Installing Playwright Test (yarn add --dev @playwright/test)…');
     expect(stdout).toContain('Installing Types (yarn add --dev @types/node)…');
@@ -57,7 +57,7 @@ test('should generate a project in the current directory', async ({ run, dir, pa
 });
 
 test('should generate a project in a given directory', async ({ run, dir, packageManager }) => {
-  test.skip(packageManager === 'yarn');
+  test.skip(packageManager === 'yarn-classic' || packageManager === 'yarn-berry');
   await run(['foobar'], { installGitHubActions: true, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: true });
   expect(fs.existsSync(path.join(dir, 'foobar/tests/example.spec.ts'))).toBeTruthy();
   expect(fs.existsSync(path.join(dir, 'foobar/package.json'))).toBeTruthy();


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/create-playwright/pull/138. Because the implementation hard-codes which Yarn it calls, there's no to test both yarn versions in parallel. This somehow slipped the last PR.

This PR changes it so that we have two separate ones, and we change the global yarn version in between.