### PR TITLE
fix: install yarn berry globally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
     - run: yarn set version stable
-      working-directory: /home/runner/
+      working-directory: ../
     - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - run: npx playwright install-deps
     - run: npm run build
     - run: npx tsc --noEmit
-    - run: npx playwright test -- --grep-invert yarn-berry
+    - run: npx playwright test --grep-invert yarn-berry
     - run: corepack enable
     - run: corepack prepare yarn@4 --activate
-    - run: npx playwright test -- --grep yarn-berry
+    - run: npx playwright test --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
     - run: npm run build
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
-    - run: cd $HOME && yarn set version stable
-      shell: bash
+    - run: corepack enable
+    - run: corepack prepare yarn@4 --activate
     - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,5 @@ jobs:
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
     - run: yarn set version stable
+      working-directory: /
     - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
     - run: yarn set version stable
-      working-directory: /
+      working-directory: /home/runner/
     - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,5 @@ jobs:
     - run: npm run build
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
-    - run: yarn set version stable
-      working-directory: ../
+    - run: cd $HOME && yarn set version stable
     - run: npm run test -- --grep yarn-berry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,5 @@ jobs:
     - run: npx tsc --noEmit
     - run: npm run test -- --grep-invert yarn-berry
     - run: cd $HOME && yarn set version stable
+      shell: bash
     - run: npm run test -- --grep yarn-berry

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import childProcess from 'child_process';
-import fs, { mkdirSync } from 'fs';
+import fs from 'fs';
 import path from 'path';
 import { assertLockFilesExist, expect, packageManagerToNpxCommand, test } from './baseFixtures';
 
@@ -171,12 +171,12 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
 
 test('is proper yarn classic', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-classic');
-  mkdirSync(test.info().outputDir)
+  fs.mkdirSync(test.info().outputDir)
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^1\./);
 });
 
 test('is proper yarn berry', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-berry');
-  mkdirSync(test.info().outputDir)
+  fs.mkdirSync(test.info().outputDir)
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^4\./);
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import childProcess from 'child_process';
-import fs from 'fs';
+import fs, { mkdirSync } from 'fs';
 import path from 'path';
 import { assertLockFilesExist, expect, packageManagerToNpxCommand, test } from './baseFixtures';
 
@@ -171,10 +171,12 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
 
 test('is proper yarn classic', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-classic');
+  mkdirSync(test.info().outputDir)
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^1\./);
 });
 
 test('is proper yarn berry', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-berry');
+  mkdirSync(test.info().outputDir)
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^4\./);
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -171,12 +171,12 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
 
 test('is proper yarn classic', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-classic');
-  fs.mkdirSync(test.info().outputDir)
+  fs.mkdirSync(test.info().outputDir);
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^1\./);
 });
 
 test('is proper yarn berry', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-berry');
-  fs.mkdirSync(test.info().outputDir)
+  fs.mkdirSync(test.info().outputDir);
   expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^4\./);
 });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -171,10 +171,10 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
 
 test('is proper yarn classic', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-classic');
-  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8' })).toMatch(/^1\./);
+  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^1\./);
 });
 
 test('is proper yarn berry', async ({ packageManager }) => {
   test.skip(packageManager !== 'yarn-berry');
-  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8' })).toMatch(/^4\./);
+  expect(childProcess.execSync('yarn --version', { encoding: 'utf-8', cwd: test.info().outputDir })).toMatch(/^4\./);
 });


### PR DESCRIPTION
The current `yarn set version stable` only installs yarn berry inside the repository. But since tests are running in $TMP, they're not subject to that. Using corepack was the only way I could find to install Yarn berry globally. I've updated tests to ensure that.