### PR TITLE
devops: use `--provenance` when publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,6 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Similar to how we do it upstream: https://github.com/microsoft/playwright/blob/e2c8163b145d4a34f4585fc11a8a2643b9c94f98/utils/publish_all_packages.sh#L97

Reference: https://docs.npmjs.com/generating-provenance-statements