### PR TITLE
devops: fix npm publishing due to proverance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Like [upstream](https://github.com/microsoft/playwright/blob/3ad5c2731a3ccccbd8468ef14a88b1edd45867a4/.github/workflows/publish_release_npm.yml#L15) and in the [docs](https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow).