### PR TITLE
chore: adjust package.json > repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "create-playwright",
   "version": "1.17.136",
   "description": "Getting started with writing end-to-end tests with Playwright.",
-  "repository": "github:Microsoft/create-playwright",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/create-playwright.git"
+  },
   "homepage": "https://playwright.dev",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Fixes https://github.com/microsoft/create-playwright/actions/runs/15213460958/job/42793133179#step:5:47

Problem: different capitalisation.

drive-by: align the way we pass the metadata like we do upstream.