### PR TITLE
chore: disable /playwright/.auth dir

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -278,7 +278,8 @@ export class Generator {
       '/test-results/': /^\/?test-results\/?$/m,
       '/playwright-report/': /^\/playwright-report\/?$/m,
       '/blob-report/': /^\/blob-report\/?$/m,
-      '/playwright/.cache/': /^\/playwright\/\.cache\/?$/m
+      '/playwright/.cache/': /^\/playwright\/\.cache\/?$/m,
+      '/playwright/.auth/': /^\/playwright\/\.auth\/?$/m,
     };
     Object.entries(valuesToAdd).forEach(([value, regex]) => {
       if (!gitIgnore.match(regex)) {

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -24,6 +24,7 @@ const validGitignore = [
   '/playwright-report/',
   '/blob-report/',
   '/playwright/.cache/',
+  '/playwright/.auth/'
 ].join('\n');
 
 test('should generate a project in the current directory', async ({ run, dir, packageManager }) => {


### PR DESCRIPTION
We discourage checking this file in in https://playwright.dev/docs/auth#core-concepts, so let's ignore it by default.