### PR TITLE
Avoid type error in generated config

### DIFF
--- a/assets/playwright-ct.config.js
+++ b/assets/playwright-ct.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  ...(!!process.env.CI && { workers: 1 }),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright-ct.config.ts
+++ b/assets/playwright-ct.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  ...(!!process.env.CI && { workers: 1 }),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  ...(!!process.env.CI && { workers: 1 }),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  ...(!!process.env.CI && { workers: 1 }),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Fix the type error in Playwright config files `playwright-ct.config.js`, `playwright-ct.config.ts`, `playwright.config.js`, `playwright.config.ts` which appears immediately after scaffolding:

```bash
$ mkdir c && cd c
$ npm init --yes
...
$ npm add --save-dev typescript @types/node
...
$ npm init playwright@latest
...
$ npx tsc
playwright.config.ts:14:29 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type '{ testDir: string; fullyParallel: true; forbidOnly: boolean; retries: number; workers: number | undefined; reporter: "html"; use: { trace: "on-first-retry"; }; projects: { name: string; use: { viewport: ViewportSize; ... 4 more ...; defaultBrowserType: "chromium" | "firefox" | "webkit"; }; }[]; }' is not assignable to parameter of type 'PlaywrightTestConfig<unknown, unknown>' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
      Types of property 'workers' are incompatible.
        Type 'number | undefined' is not assignable to type 'string | number'.
          Type 'undefined' is not assignable to type 'string | number'.

 14 export default defineConfig({
                                ~
 15   testDir: './tests',
    ~~~~~~~~~~~~~~~~~~~~~
... 
 78   // },
    ~~~~~~~
 79 });
    ~

  node_modules/playwright/types/test.d.ts:8410:17
    8410 export function defineConfig<T, W>(config: PlaywrightTestConfig<T, W>, ...configs: PlaywrightTestConfig<T, W>[]): PlaywrightTestConfig<T, W>;
                         ~~~~~~~~~~~~
    The last overload is declared here.
```

<img width="1604" height="986" alt="Screenshot 2025-09-10 at 16 23 22" src="https://github.com/user-attachments/assets/ef8a68be-2540-428f-ae15-e312aec47bc9" />

After the change:

<img width="1048" height="516" alt="Screenshot 2025-09-10 at 16 28 19" src="https://github.com/user-attachments/assets/5940695d-0d63-437b-ac3c-395ae08d884a" />
