### PR TITLE
fix: ask for language and browser install

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ program
   .name('create-playwright')
   .description('Getting started with writing end-to-end tests with Playwright.')
   .argument('[rootDir]', 'Target directory for the Playwright project', '.')
-  .option('--browser <browser...>', 'browsers to use in default config', ['chromium', 'firefox', 'webkit'])
+  .option('--browser <browser...>', 'browsers to use in default config')
   .option('--no-browsers', 'do not download browsers (can be done manually via \'npx playwright install\')')
   .option('--no-examples', 'do not create example test files')
   .option('--install-deps', 'install dependencies')
@@ -33,7 +33,7 @@ program
   .option('--ct', 'install Playwright Component testing')
   .option('--quiet', 'do not ask for interactive input prompts')
   .option('--gha', 'install GitHub Actions')
-  .option('--lang <language>', 'language to use (js, TypeScript)', 'TypeScript')
+  .option('--lang <language>', 'language to use (js, TypeScript)')
   .action(async (rootDir, options) => {
 
     const cliOptions: CliOptions = {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -35,8 +35,8 @@ export type PromptOptions = {
 const assetsDir = path.join(__dirname, '..', 'assets');
 
 export type CliOptions = {
-  lang: string;
-  browser: string[];
+  lang?: string;
+  browser?: string[];
   noBrowsers?: boolean;
   noExamples?: boolean;
   installDeps?: boolean;


### PR DESCRIPTION
https://github.com/microsoft/create-playwright/commit/39fa746f5271193360e40cbe989e7ef7d6b1054e regressed the language and browser installation questions by providing default values to Commander.js, which meant we always set `skip: true` on those questions. Fixing by turning them back into optionals, the questionnaire makes sure we set default values. Closes https://github.com/microsoft/playwright/issues/37742.