### PR TITLE
fix: ensure non-TTY agents dont hang

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ program
   .option('--quiet', 'do not ask for interactive input prompts')
   .option('--gha', 'install GitHub Actions')
   .option('--lang <language>', 'language to use (js, TypeScript)')
-  .option('--test-dir <directory>', 'directory for test files (default: "tests" if unused, otherwise "e2e")')
+  .option('--test-dir <directory>', 'directory for test files (default: "tests" if it does not exist, otherwise "e2e")')
   .action(async (rootDir, options) => {
 
     const cliOptions: CliOptions = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,7 @@ program
   .option('--quiet', 'do not ask for interactive input prompts')
   .option('--gha', 'install GitHub Actions')
   .option('--lang <language>', 'language to use (js, TypeScript)')
+  .option('--test-dir <directory>', 'directory for test files (default: "tests" if unused, otherwise "e2e")')
   .action(async (rootDir, options) => {
 
     const cliOptions: CliOptions = {
@@ -47,6 +48,7 @@ program
       quiet: options.quiet,
       gha: options.gha,
       lang: options.lang,
+      testDir: options.testDir,
     };
     const resolvedRootDir = path.resolve(process.cwd(), rootDir || '.');
     const generator = new Generator(resolvedRootDir, cliOptions);

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -67,7 +67,7 @@ export class Generator {
       return acc;
     }, [[] as Command[], [] as Command[]]);
     executeCommands(this.rootDir, preCommands);
-    await createFiles(this.rootDir, files);
+    await createFiles(this.rootDir, files, false, !!this.options.quiet);
     this._patchGitIgnore();
     await this._patchPackageJSON(answers);
     executeCommands(this.rootDir, postCommands);
@@ -316,7 +316,7 @@ export class Generator {
 
     const files = new Map<string, string>();
     files.set('package.json', JSON.stringify(packageJSON, null, 2) + '\n'); // NPM keeps a trailing new-line
-    await createFiles(this.rootDir, files, true);
+    await createFiles(this.rootDir, files, true, false);
   }
 
   private _printEpilogue(answers: PromptOptions) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -45,6 +45,7 @@ export type CliOptions = {
   ct?: boolean;
   quiet?: boolean;
   gha?: boolean;
+  testDir?: string;
 };
 
 export class Generator {
@@ -85,12 +86,15 @@ export class Generator {
   private async _askQuestions(): Promise<PromptOptions> {
     if (process.env.TEST_OPTIONS)
       return JSON.parse(process.env.TEST_OPTIONS);
+
+    const testDir = this.options.testDir || (fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests');
+
     if (this.options.quiet) {
       return {
         installGitHubActions: !!this.options.gha,
         language: this.options.lang === 'js' ? 'JavaScript' : 'TypeScript',
         installPlaywrightDependencies: !!this.options.installDeps,
-        testDir: fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests',
+        testDir,
         framework: undefined,
         installPlaywrightBrowsers: !this.options.noBrowsers,
       };
@@ -131,7 +135,8 @@ export class Generator {
         type: 'text',
         name: 'testDir',
         message: 'Where to put your end-to-end tests?',
-        initial: fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests',
+        initial: testDir,
+        skip: !!this.options.testDir,
       },
       !this.options.ct && {
         type: 'confirm',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -95,6 +95,10 @@ export class Generator {
         installPlaywrightBrowsers: !this.options.noBrowsers,
       };
     }
+    if (!process.stdin.isTTY) {
+      console.error('Non-interactive terminal detected. See --help for options, then run again with --quiet.');
+      process.exit(1);
+    }
 
     const isDefinitelyTS = fs.existsSync(path.join(this.rootDir, 'tsconfig.json'));
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -99,10 +99,6 @@ export class Generator {
         installPlaywrightBrowsers: !this.options.noBrowsers,
       };
     }
-    if (!process.stdin.isTTY) {
-      console.error('Non-interactive terminal detected. See --help for options, then run again with --quiet.');
-      process.exit(1);
-    }
 
     const isDefinitelyTS = fs.existsSync(path.join(this.rootDir, 'tsconfig.json'));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,10 +37,20 @@ export function executeCommands(cwd: string, commands: Command[]) {
   }
 }
 
-export async function createFiles(rootDir: string, files: Map<string, string>, force: boolean = false) {
+export async function createFiles(rootDir: string, files: Map<string, string>, force: boolean, quiet: boolean) {
+  const existingFiles = [...files.keys()].filter(f => fs.existsSync(path.join(rootDir, f)));
+  if (quiet && !force && existingFiles.length) {
+    console.log('These files already exist:');
+    for (const f of existingFiles)
+      console.log(`  ${path.relative(process.cwd(), f)}`);
+    console.log('If you want to override them, run again with --force.');
+    process.exit(1);
+    return;
+  }
+
   for (const [relativeFilePath, value] of files) {
     const absoluteFilePath = path.join(rootDir, relativeFilePath);
-    if (fs.existsSync(absoluteFilePath) && !force) {
+    if (existingFiles.includes(absoluteFilePath) && !force) {
       const { override } = await prompt<{ override: boolean }>({
         type: 'confirm',
         name: 'override',

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -175,6 +175,21 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
   expect(workflowContent).not.toContain('run: npm ci');
 });
 
+test('should not prompt and skip existing files in --quiet mode', async ({ run, dir }) => {
+  // First run: generate the project normally
+  await run([], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
+  const originalConfig = fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8');
+
+  // Second run: use --quiet, existing files should be skipped without prompting
+  const { stdout, code } = await run(['--quiet'], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
+  expect(stdout).toContain('These files already exist:');
+  expect(stdout).toContain('run again with --force');
+  expect(code).toBe(1);
+
+  // Verify the existing file was not overwritten
+  expect(fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8')).toBe(originalConfig);
+});
+
 test('is proper yarn classic', async ({ packageManager, exec }) => {
   test.skip(packageManager !== 'yarn-classic');
   const result = await exec('yarn --version', [], { cwd: test.info().outputDir, shell: true });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -187,10 +187,6 @@ test('should not prompt and skip existing files in --quiet mode', async ({ run, 
   expect(fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8')).toBe(originalConfig);
 });
 
-test('should require --quiet for non-interactive terminals', async ({ exec }) => {
-  await expect(exec('node', [path.join(__dirname, '..')])).rejects.toThrow('Non-interactive terminal detected');
-});
-
 test('is proper yarn classic', async ({ packageManager, exec }) => {
   test.skip(packageManager !== 'yarn-classic');
   const result = await exec('yarn --version', [], { cwd: test.info().outputDir, shell: true });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -181,13 +181,14 @@ test('should not prompt and skip existing files in --quiet mode', async ({ run, 
   const originalConfig = fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8');
 
   // Second run: use --quiet, existing files should be skipped without prompting
-  const { stdout, code } = await run(['--quiet'], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false });
-  expect(stdout).toContain('These files already exist:');
-  expect(stdout).toContain('run again with --force');
-  expect(code).toBe(1);
-
+  await expect(run(['--quiet'], { installGitHubActions: false, testDir: 'tests', language: 'TypeScript', installPlaywrightDependencies: false, installPlaywrightBrowsers: false })).rejects.toThrowError("run again with --force");
+  
   // Verify the existing file was not overwritten
   expect(fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8')).toBe(originalConfig);
+});
+
+test('should require --quiet for non-interactive terminals', async ({ exec }) => {
+  await expect(exec('node', [path.join(__dirname, '..')])).rejects.toThrow('Non-interactive terminal detected');
 });
 
 test('is proper yarn classic', async ({ packageManager, exec }) => {


### PR DESCRIPTION
Closes https://github.com/microsoft/playwright/issues/39986:

- prevents `createFiles` from hanging in quiet mode
- add `--test-dir` flag, which was only configurable interactively before