### PR TITLE
fix: error on non-interactive terminals without --quiet

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -95,6 +95,10 @@ export class Generator {
         installPlaywrightBrowsers: !this.options.noBrowsers,
       };
     }
+    if (!process.stdin.isTTY) {
+      console.error('Non-interactive terminal detected. See --help for options, then run again with --quiet.');
+      process.exit(1);
+    }
 
     const isDefinitelyTS = fs.existsSync(path.join(this.rootDir, 'tsconfig.json'));
 

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -175,6 +175,10 @@ test('should install with "npm i" in GHA when using npm with package-lock disabl
   expect(workflowContent).not.toContain('run: npm ci');
 });
 
+test('should require --quiet for non-interactive terminals', async ({ exec }) => {
+  await expect(exec('node', [path.join(__dirname, '..')])).rejects.toThrow('Non-interactive terminal detected');
+});
+
 test('is proper yarn classic', async ({ packageManager, exec }) => {
   test.skip(packageManager !== 'yarn-classic');
   const result = await exec('yarn --version', [], { cwd: test.info().outputDir, shell: true });


### PR DESCRIPTION
When a non-interactive terminal (e.g. a coding agent spawning with `stdio: ['pipe', ...]`) runs `create-playwright` without `--quiet`, enquirer prompts hang indefinitely because stdin never closes.

This adds a `process.stdin.isTTY` check after the `--quiet` early return. If the terminal is non-interactive and `--quiet` wasn't passed, we print an actionable error message and exit instead of hanging.

Split out from #172 for easier revert.