### PR TITLE
fix: skip gha prompt when explicitly set

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ program
   .option('--ct', 'install Playwright Component testing')
   .option('--quiet', 'do not ask for interactive input prompts')
   .option('--gha', 'install GitHub Actions')
+  .option('--no-gha', 'do not install GitHub Actions')
   .option('--lang <language>', 'language to use (js, TypeScript)')
   .option('--test-dir <directory>', 'directory for test files (default: "tests" if it does not exist, otherwise "e2e")')
   .action(async (rootDir, options) => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -89,7 +89,7 @@ export class Generator {
 
     const testDir = this.options.testDir || (fs.existsSync(path.join(this.rootDir, 'tests')) ? 'e2e' : 'tests');
 
-    if (this.options.quiet) {
+    if (this.options.quiet || !process.stdin.isTTY) {
       return {
         installGitHubActions: !!this.options.gha,
         language: this.options.lang === 'js' ? 'JavaScript' : 'TypeScript',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -111,7 +111,7 @@ export class Generator {
           { name: 'TypeScript' },
           { name: 'JavaScript' },
         ],
-        initial: this.options.lang === 'js' ? 'JavaScript' : 'TypeScript',
+        initial: this.options.lang === 'js' ? 1 : 0,
         skip: !!this.options.lang,
       },
       this.options.ct && {
@@ -138,8 +138,8 @@ export class Generator {
         type: 'confirm',
         name: 'installGitHubActions',
         message: 'Add a GitHub Actions workflow?',
-        initial: true,
-        skip: !!this.options.gha,
+        initial: this.options.gha ?? true,
+        skip: this.options.gha !== undefined,
       },
       {
         type: 'confirm',

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -101,6 +101,7 @@ export class Generator {
     }
 
     const isDefinitelyTS = fs.existsSync(path.join(this.rootDir, 'tsconfig.json'));
+    const cliOptions = this.options;
 
     const questions = [
       !isDefinitelyTS && {
@@ -111,8 +112,12 @@ export class Generator {
           { name: 'TypeScript' },
           { name: 'JavaScript' },
         ],
-        initial: this.options.lang === 'js' ? 1 : 0,
-        skip: !!this.options.lang,
+        skip(this: { index: number }) {
+          if (!cliOptions.lang)
+            return false;
+          this.index = cliOptions.lang === 'js' ? 1 : 0;
+          return true;
+        },
       },
       this.options.ct && {
         type: 'select',

--- a/tests/baseFixtures.ts
+++ b/tests/baseFixtures.ts
@@ -33,7 +33,7 @@ const userAgents: Record<PackageManager, string | undefined> = {
 export type TestFixtures = {
   packageManager: PackageManager;
   dir: string;
-  run: (parameters: string[], options: PromptOptions) => Promise<SpawnResult>,
+  run: (parameters: string[], options?: PromptOptions) => Promise<SpawnResult>,
   exec: typeof spawnAsync,
 };
 
@@ -86,13 +86,13 @@ export const test = base.extend<TestFixtures>({
     });
   },
   run: async ({ packageManager, exec, dir }, use) => {
-    await use(async (parameters: string[], options: PromptOptions): Promise<SpawnResult> => {
+    await use(async (parameters: string[], options?: PromptOptions): Promise<SpawnResult> => {
       return await exec('node', [path.join(__dirname, '..'), ...parameters], {
         cwd: dir,
         env: {
           ...process.env,
           npm_config_user_agent: userAgents[packageManager],
-          'TEST_OPTIONS': JSON.stringify(options),
+          ...(options ? { TEST_OPTIONS: JSON.stringify(options) } : {}),
         },
       });
     });

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -187,6 +187,30 @@ test('should not prompt and skip existing files in --quiet mode', async ({ run, 
   expect(fs.readFileSync(path.join(dir, 'playwright.config.ts'), 'utf8')).toBe(originalConfig);
 });
 
+test('should skip GHA prompt and install workflow when --gha is passed', async ({ run, dir }) => {
+  await run(['--quiet', '--gha', '--lang', 'js', '--test-dir', 'specs', '--no-browsers']);
+
+  expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeTruthy();
+  expect(fs.existsSync(path.join(dir, 'specs/example.spec.js'))).toBeTruthy();
+  expect(fs.readFileSync(path.join(dir, 'playwright.config.js'), 'utf8')).toContain('specs');
+});
+
+test('should skip GHA prompt and not install workflow when --no-gha is passed', async ({ run, dir }) => {
+  await run(['--quiet', '--no-gha', '--lang', 'js', '--test-dir', 'specs', '--no-browsers']);
+
+  expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeFalsy();
+  expect(fs.existsSync(path.join(dir, 'specs/example.spec.js'))).toBeTruthy();
+  expect(fs.readFileSync(path.join(dir, 'playwright.config.js'), 'utf8')).toContain('specs');
+});
+
+test('should skip GHA prompt without --quiet when --no-gha is passed', async ({ run, dir }) => {
+  await run(['--no-gha', '--lang', 'js', '--test-dir', 'specs', '--no-browsers', '--install-deps']);
+
+  expect(fs.existsSync(path.join(dir, '.github/workflows/playwright.yml'))).toBeFalsy();
+  expect(fs.existsSync(path.join(dir, 'specs/example.spec.js'))).toBeTruthy();
+  expect(fs.readFileSync(path.join(dir, 'playwright.config.js'), 'utf8')).toContain('specs');
+});
+
 test('is proper yarn classic', async ({ packageManager, exec }) => {
   test.skip(packageManager !== 'yarn-classic');
   const result = await exec('yarn --version', [], { cwd: test.info().outputDir, shell: true });


### PR DESCRIPTION
alternative to #173

- add `--no-gha` to the CLI
- treat explicit `--gha` / `--no-gha` as answered so the GitHub Actions prompt is skipped
- use a numeric `initial` index for the language `select` prompt so skipped `--lang js` resolves correctly in the non-quiet path
- add integration coverage for explicit GHA flags in quiet and non-quiet flows

## Context
This PR is an alternative to #173  for the remaining `--gha` / `--no-gha` prompt-skipping gap from the linked review comment.
