### PR TITLE
feat: generate globalTimeout, drop the job timeout from the workflow

### DIFF
--- a/assets/github-actions.yml
+++ b/assets/github-actions.yml
@@ -6,7 +6,6 @@ on:
     branches: [ main, master ]
 jobs:
   test:
-    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/assets/playwright-ct.config.js
+++ b/assets/playwright-ct.config.js
@@ -16,6 +16,8 @@ module.exports = defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Limit the whole test run, so that it fails with a report instead of hanging. */
+  globalTimeout: 60 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright-ct.config.ts
+++ b/assets/playwright-ct.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Limit the whole test run, so that it fails with a report instead of hanging. */
+  globalTimeout: 60 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright.config.js
+++ b/assets/playwright.config.js
@@ -20,6 +20,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Limit the whole test run, so that it fails with a report instead of hanging. */
+  globalTimeout: 60 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/assets/playwright.config.ts
+++ b/assets/playwright.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Limit the whole test run, so that it fails with a report instead of hanging. */
+  globalTimeout: 60 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Summary
- Generated configs now set `globalTimeout: 60 * 60 * 1000`, so an over-running suite fails with a report instead of hanging.
- The generated GitHub Actions workflow no longer sets a job-level `timeout-minutes`, which would kill the run mid-flight and produce no report.

Docs counterpart: https://github.com/microsoft/playwright/pull/42563
References https://github.com/microsoft/playwright/issues/42533